### PR TITLE
Fix mobile header links & user login

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -18,9 +18,9 @@ function App() {
         <Routes>
           <Route path="/" element={<Layout />}>
             {/* public routes */}
+            <Route path="/login" element={<Login />} />
             <Route element={<PersistLogin />}>
               <Route path="/signup" element={<Signup />} />
-              <Route path="/login" element={<Login />} />
             </Route>
 
             {/* private routes */}

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -25,7 +25,7 @@ export function Footer() {
             </div>
             <div className="ml-8 lg:w-64">
               <p className="text-base font-semibold text-gray-900">
-                <Link to="#">
+                <Link to="/login">
                   <span className="absolute inset-0 sm:rounded-2xl" />
                   Login now
                 </Link>

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -39,6 +39,7 @@ function ChevronUpIcon(props) {
 function MobileNavLink({ children, ...props }) {
   return (
     <Popover.Button
+      as={Link}
       className="block text-base leading-7 tracking-tight text-gray-700"
       {...props}
     >
@@ -103,15 +104,13 @@ export function Header() {
                           className="absolute inset-x-0 top-0 z-0 px-6 pt-32 pb-6 origin-top shadow-2xl rounded-b-2xl bg-gray-50 shadow-gray-900/20"
                         >
                           <div className="space-y-4">
-                            <MobileNavLink href="/">Home</MobileNavLink>
-                            <MobileNavLink href="/profile">
-                              Profile
-                            </MobileNavLink>
-                            <MobileNavLink href="#reviews">Match</MobileNavLink>
-                            <MobileNavLink href="#pricing">
+                            <MobileNavLink to="/">Home</MobileNavLink>
+                            <MobileNavLink to="/profile">Profile</MobileNavLink>
+                            <MobileNavLink to="/match">Match</MobileNavLink>
+                            <MobileNavLink to="/learning">
                               Learning History
                             </MobileNavLink>
-                            <MobileNavLink href="#faqs">
+                            <MobileNavLink to="/questions">
                               Question Bank
                             </MobileNavLink>
                           </div>


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance or refactor
- [ ] Test
- [ ] DevOps
- [ ] Others:

**Overview of changes**
Fixes #94
Fixes #89 
- remove the persisting of user across refresh for the `/login` route as that triggers the automatic login when user clicks on the persist box
- this means that if the user manually refreshes on `/login` then he/she will be logged out, which should be ok because in general after an user is logged in, he/she won't be/need to go to the login page
- if the user goes to the login page via available links such as in the footer (there's a button on the right), then the user can still stay logged in, as long as he does not manually refresh

**How it was tested/How to test**
For mobile header
- Run the services
- Reduce window width such that the header is hidden in the menu icon
- check the header nav links and click on them to ensure that the links are now able to direct to the relevant pages

For user login
- Goto login page
- use `qwe` user details
- toggle the `persist login` checkbox and see that it won't log the user in

**Service(s) Touched**

- [x] Frontend
- [ ] User Service
- [ ] Matching Service
- [ ] Question Service
- [ ] Collaboration Service
