### PR TITLE
Add end room session logic

### DIFF
--- a/frontend/src/components/QuestionPane.jsx
+++ b/frontend/src/components/QuestionPane.jsx
@@ -7,7 +7,6 @@ import {
   Heading,
   Divider,
 } from '@chakra-ui/react'
-import { AuthLayout } from '../components/AuthLayout'
 import useFetchQuestionById from '../hooks/useFetchQuestionById'
 import ChakraUIRenderer from 'chakra-ui-markdown-renderer'
 import ReactMarkdown from 'react-markdown'

--- a/frontend/src/components/QuestionPane.jsx
+++ b/frontend/src/components/QuestionPane.jsx
@@ -1,25 +1,29 @@
-import { Text, Box, Badge, HStack, VStack, Heading, Divider } from '@chakra-ui/react'
-import { AuthLayout } from '../components/AuthLayout';
-import useFetchQuestionById from '../hooks/useFetchQuestionById';
-import ChakraUIRenderer from 'chakra-ui-markdown-renderer';
+import {
+  Text,
+  Box,
+  Badge,
+  HStack,
+  VStack,
+  Heading,
+  Divider,
+} from '@chakra-ui/react'
+import { AuthLayout } from '../components/AuthLayout'
+import useFetchQuestionById from '../hooks/useFetchQuestionById'
+import ChakraUIRenderer from 'chakra-ui-markdown-renderer'
 import ReactMarkdown from 'react-markdown'
 
 const difficultyColorMap = new Map([
-    ['easy', 'green'],
-    ['medium', 'orange'],
-    ['hard', 'red']
+  ['easy', 'green'],
+  ['medium', 'orange'],
+  ['hard', 'red'],
 ])
 
 const newTheme = {
-  p: props => {
-    const { children } = props;
-    return (
-      <Text className='text-sm'>
-        {children}
-      </Text>
-    );
+  p: (props) => {
+    const { children } = props
+    return <Text className="text-sm">{children}</Text>
   },
-};
+}
 
 // Prettify the question text
 // TODO: fix the root issue when storing questions in DB
@@ -31,42 +35,46 @@ const parse = (text) => {
 }
 
 const QuestionPane = ({ id }) => {
-    const {
-        data,
-        loading,
-      } = useFetchQuestionById(id);
-    
-    const difficultyColor = difficultyColorMap.get(data.difficulty)
+  const { data, loading } = useFetchQuestionById(id)
 
-    return (
-        <>
-            { !loading ?
-            (
-                <Box className='border rounded-lg'>
-                    <VStack h='100vh'>
-                        <HStack spacing='24px'>
-                            <Heading size='lg' fontWeight='semibold' color='gray 500'>
-                              {data.name}
-                            </Heading> 
-                            <Badge borderRadius='full' px='2' colorScheme={difficultyColor}>
-                                {data.difficulty}
-                            </Badge>
-                        </HStack>
+  const difficultyColor = (difficulty) => difficultyColorMap.get(difficulty)
 
-                        <Divider orientation='horizontal' />
+  return (
+    <>
+      <Box className="rounded-lg border">
+        <VStack h="100vh">
+          {loading || !data ? (
+            <div className="text-center text-xl">Retrieving Question</div>
+          ) : (
+            <>
+              <HStack spacing="24px">
+                <Heading size="lg" fontWeight="semibold" color="gray 500">
+                  {data.name}
+                </Heading>
+                <Badge
+                  borderRadius="full"
+                  px="2"
+                  colorScheme={difficultyColor(data.difficulty)}
+                >
+                  {data.difficulty}
+                </Badge>
+              </HStack>
 
-                        <div className="mx-2 px-2 max-h-full overflow-y-auto">
-                            <ReactMarkdown components={ChakraUIRenderer(newTheme)} children={parse(data.content)} skipHtml/>;
-                        </div>
-                    </VStack>
-                </Box>
-            ) : <AuthLayout title="Retrieving question...">
-            <div className="text-xl text-center">
-            </div>
-          </AuthLayout>}
-        </>
+              <Divider orientation="horizontal" />
 
-    )
+              <div className="mx-2 max-h-full overflow-y-auto px-2">
+                <ReactMarkdown
+                  components={ChakraUIRenderer(newTheme)}
+                  children={parse(data.content)}
+                  skipHtml
+                />
+              </div>
+            </>
+          )}
+        </VStack>
+      </Box>
+    </>
+  )
 }
 
 export default QuestionPane

--- a/frontend/src/components/room/RoomEndDialog.jsx
+++ b/frontend/src/components/room/RoomEndDialog.jsx
@@ -1,0 +1,50 @@
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  Button,
+  useDisclosure,
+  ModalHeader,
+  ModalCloseButton,
+  ModalBody,
+  ModalFooter,
+} from '@chakra-ui/react'
+import React from 'react'
+
+const RoomEndDialog = ({ handleClick }) => {
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  return (
+    <>
+      <Button onClick={onOpen}>End Session</Button>
+
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Are you sure?</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            Ending the session will close the room for both users and questions
+            completed will be reflected in your match history.
+          </ModalBody>
+
+          <ModalFooter>
+            <Button variant="ghost" mr={3} onClick={onClose}>
+              Cancel
+            </Button>
+            <Button
+              colorScheme="blue"
+              onClick={() => {
+                onClose()
+                handleClick()
+              }}
+            >
+              Confirm
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  )
+}
+
+export default RoomEndDialog

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -13,9 +13,9 @@ export const URL_USER_SIGNUP = URL_USER_SERVICE + '/signup'
 export const URL_USER_TOKEN = URL_USER_SERVICE + '/token'
 export const URL_USER_TOKEN_TEST = URL_USER_SERVICE + '/testToken'
 
-
 // QUESTION SERVICE API
-const URI_QUESTION_SERVICE = process.env.URI_QUESTION_SERVICE || 'http://localhost:8500'
+const URI_QUESTION_SERVICE =
+  process.env.URI_QUESTION_SERVICE || 'http://localhost:8500'
 export const URL_QUESTION_SERVICE = URI_QUESTION_SERVICE + '/api/v1/question'
 export const PASSWORD_REGEX =
   /^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#$%]).{8,24}$/
@@ -36,6 +36,7 @@ export const EVENT_LISTEN = {
   MATCH_SUCCESS: 'matchSuccess',
   MATCH_FAIL: 'matchFail',
   MATCH_TIMEOUT: 'matchTimeout',
+  ROOM_END: 'roomEnd',
 }
 
 export const EVENT_EMIT = {

--- a/frontend/src/hooks/useFetchQuestionById.js
+++ b/frontend/src/hooks/useFetchQuestionById.js
@@ -1,30 +1,32 @@
-import axios from '../api/axios';
-import {useState, useEffect} from 'react'
-import { URL_QUESTION_SERVICE } from '../constants';
+import axios from '../api/axios'
+import { useState, useEffect } from 'react'
+import { URL_QUESTION_SERVICE } from '../constants'
 
 const useFetchQuestionById = (questionId) => {
-    const [loading, setLoading] = useState(true);
-    const [data, setData] = useState([])
-  
-    useEffect(() => {
-        const fetchData = async () =>{
-          setLoading(true);
-          try {
-            const {data: response} = await axios.get(URL_QUESTION_SERVICE + '?id=' + (questionId ? questionId : '1'))
-            setData(response);
-          } catch (error) {
-            //todo toast
-            console.error(error);
-          }
-          setLoading(false);
-        }
-        fetchData();
-      }, [questionId]);
-  
-    return {
-        data,
-        loading
-    };
+  const [loading, setLoading] = useState(true)
+  const [data, setData] = useState()
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true)
+      try {
+        const { data: response } = await axios.get(
+          URL_QUESTION_SERVICE + '?id=' + (questionId ? questionId : '1')
+        )
+        setData(response)
+      } catch (error) {
+        //todo toast
+        console.error(error)
+      }
+      setLoading(false)
+    }
+    fetchData()
+  }, [questionId])
+
+  return {
+    data,
+    loading,
   }
-  
-  export default useFetchQuestionById
+}
+
+export default useFetchQuestionById

--- a/frontend/src/pages/Room.jsx
+++ b/frontend/src/pages/Room.jsx
@@ -1,7 +1,11 @@
 import { useNavigate, useParams } from 'react-router-dom'
 import axios from '../api/axios'
 import { useEffect, useState } from 'react'
-import { URL_MATCHING_ROOM, STATUS_CODE_SUCCESS, STATUS_CODE_BAD_REQUEST } from '../constants'
+import {
+  URL_MATCHING_ROOM,
+  STATUS_CODE_SUCCESS,
+  STATUS_CODE_BAD_REQUEST,
+} from '../constants'
 import { useToast } from '@chakra-ui/react'
 import { Helmet } from 'react-helmet-async'
 import QuestionPane from '../components/QuestionPane'
@@ -21,12 +25,14 @@ const Room = () => {
 
   const getQuestionId = async () => {
     const res = await axios.get(`${URL_MATCHING_ROOM}/${roomId}`).catch((e) => {
-      if (e.response.status === STATUS_CODE_BAD_REQUEST) { // Room not found
+      if (e.response.status === STATUS_CODE_BAD_REQUEST) {
+        // Room not found
         return setIsValid(false)
       }
     })
     if (res && res.status === STATUS_CODE_SUCCESS) {
       setQuestionId(res.data.data.questionId)
+      console.log(res.data.data.questionId)
     }
   }
 
@@ -54,41 +60,29 @@ const Room = () => {
     )
   }
 
-  if (!isValid) {
-    return (
-      <>
-        {getHelmet()}
-        <main className="flex h-full flex-col items-center justify-start">
-          <h1>Invalid Room... The session has ended.</h1>
-        </main>
-      </>
-    )
-  }
-
-  if (!questionId) {
-    return (
-      <>
-        {getHelmet()}
-        <main className="flex h-full flex-col items-center justify-start">
-          <h1>Retrieving room...</h1>
-        </main>
-      </>
-    )
-  }
-
   return (
     <>
       {getHelmet()}
-      <div className="grid h-screen grid-cols-2 gap-4">
-        <QuestionPane id={questionId} />
 
-        <div className="flex flex-col justify-start">
-          <Editor roomId={roomId} />
-          <div className="flex flex-col items-center justify-start">
-            <Button onClick={endSession}>End session</Button>
+      {!isValid || !questionId ? (
+        <main className="flex h-full flex-col items-center justify-start">
+          <h1>
+            {isValid
+              ? 'Retrieving room...'
+              : 'Invalid Room... The session has ended.'}
+          </h1>
+        </main>
+      ) : (
+        <div className="grid h-screen grid-cols-2 gap-4">
+          <QuestionPane id={questionId} />
+          <div className="flex flex-col justify-start">
+            <Editor roomId={roomId} />
+            <div className="flex flex-col items-center justify-start">
+              <Button onClick={endSession}>End session</Button>
+            </div>
           </div>
         </div>
-      </div>
+      )}
     </>
   )
 }

--- a/frontend/src/pages/Room.jsx
+++ b/frontend/src/pages/Room.jsx
@@ -12,14 +12,13 @@ import QuestionPane from '../components/QuestionPane'
 import Editor from '../components/collaboration/Editor'
 import RoomEndDialog from '../components/room/RoomEndDialog'
 import io from 'socket.io-client'
-import { URI_MATCHING_SERVICE, EVENT_EMIT, EVENT_LISTEN } from '../constants'
+import { URI_MATCHING_SERVICE, EVENT_LISTEN } from '../constants'
 
 const Room = () => {
   const navigate = useNavigate()
   const { roomId } = useParams()
   const [questionId, setQuestionId] = useState()
   const [isValid, setIsValid] = useState(true)
-  const [socket, setSocket] = useState()
   const toast = useToast()
 
   useEffect(() => {
@@ -28,7 +27,6 @@ const Room = () => {
 
   useEffect(() => {
     const newSocket = io(URI_MATCHING_SERVICE)
-    setSocket(newSocket)
     newSocket.on(`${roomId}-${EVENT_LISTEN.ROOM_END}`, () => {
       toast({
         title: 'Session ended!',

--- a/frontend/src/pages/Room.jsx
+++ b/frontend/src/pages/Room.jsx
@@ -10,7 +10,7 @@ import { useToast } from '@chakra-ui/react'
 import { Helmet } from 'react-helmet-async'
 import QuestionPane from '../components/QuestionPane'
 import Editor from '../components/collaboration/Editor'
-import { Button } from '../components/Button'
+import RoomEndDialog from '../components/room/RoomEndDialog'
 import io from 'socket.io-client'
 import { URI_MATCHING_SERVICE, EVENT_EMIT, EVENT_LISTEN } from '../constants'
 
@@ -54,7 +54,6 @@ const Room = () => {
     })
     if (res && res.status === STATUS_CODE_SUCCESS) {
       setQuestionId(res.data.data.questionId)
-      console.log(res.data.data.questionId)
     }
   }
 
@@ -90,7 +89,7 @@ const Room = () => {
           <div className="flex flex-col justify-start">
             <Editor roomId={roomId} />
             <div className="flex flex-col items-center justify-start">
-              <Button onClick={endSession}>End session</Button>
+              <RoomEndDialog handleClick={endSession} />
             </div>
           </div>
         </div>

--- a/matching-service/handler/match-handler.js
+++ b/matching-service/handler/match-handler.js
@@ -36,6 +36,7 @@ exports.findMatch = async function (payload) {
     );
   } catch (e) {
     // TODO add custom error messages
+    console.error(e);
     console.log(EVENT_EMIT.MATCH_FAIL);
     socket.emit(EVENT_EMIT.MATCH_FAIL, {
       status: EVENT_EMIT.MATCH_FAIL,

--- a/matching-service/service/match-service.js
+++ b/matching-service/service/match-service.js
@@ -42,10 +42,10 @@ const MatchService = {
     await MatchService.deleteMatch(socketIdWaiting);
     console.log(EVENT_EMIT.MATCH_SUCCESS);
     const roomId = `${socketIdWaiting}|${socketIdNew}`;
-    const response = await axios.get(URL_QUESTION_SERVICE, {
-      params: { difficulty: difficulty },
-    });
-    await RoomService.createRoom(roomId, response.data.id);
+    // const response = await axios.get(URL_QUESTION_SERVICE, {
+    //   params: { difficulty: difficulty },
+    // });
+    await RoomService.createRoom(roomId, "1"); // response.data.id);
     sendMessageToBoth(socketIdWaiting, socketIdNew, EVENT_EMIT.MATCH_SUCCESS, {
       status: EVENT_EMIT.MATCH_SUCCESS,
       room: roomId,

--- a/matching-service/service/match-service.js
+++ b/matching-service/service/match-service.js
@@ -42,10 +42,10 @@ const MatchService = {
     await MatchService.deleteMatch(socketIdWaiting);
     console.log(EVENT_EMIT.MATCH_SUCCESS);
     const roomId = `${socketIdWaiting}|${socketIdNew}`;
-    // const response = await axios.get(URL_QUESTION_SERVICE, {
-    //   params: { difficulty: difficulty },
-    // });
-    await RoomService.createRoom(roomId, "1"); // response.data.id);
+    const response = await axios.get(URL_QUESTION_SERVICE, {
+      params: { difficulty: difficulty },
+    });
+    await RoomService.createRoom(roomId, response.data.id);
     sendMessageToBoth(socketIdWaiting, socketIdNew, EVENT_EMIT.MATCH_SUCCESS, {
       status: EVENT_EMIT.MATCH_SUCCESS,
       room: roomId,

--- a/matching-service/service/room-service.js
+++ b/matching-service/service/room-service.js
@@ -1,5 +1,5 @@
 const RoomRepository = require("../repository/room-repository");
-const { sendMessageToBoth } = require("../utils/socket-io");
+const { emit } = require("../utils/socket-io");
 const { EVENT_EMIT } = require("../const/constants");
 
 const RoomService = {
@@ -14,7 +14,7 @@ const RoomService = {
     if (socketIds.length !== 2) {
       throw new Error("Invalid roomId");
     }
-    sendMessageToBoth(socketIds[0], socketIds[1], EVENT_EMIT.ROOM_END, {
+    emit(`${roomId}-${EVENT_EMIT.ROOM_END}`, {
       status: EVENT_EMIT.ROOM_END,
       room: roomId,
     });

--- a/matching-service/utils/socket-io.js
+++ b/matching-service/utils/socket-io.js
@@ -21,5 +21,7 @@ exports.sendMessageToBoth = (firstSocket, secondSocket, event, message) =>
 exports.sendMessageToOne = (socket, event, message) =>
   io.to(socket).emit(event, message);
 
+exports.emit = (event, message) => io.emit(event, message);
+
 exports.isSocketActive = (socket) =>
   io.sockets.sockets.get(socket) !== undefined;


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [x] Feature addition or enhancement
- [ ] Code maintenance or refactor
- [ ] Test
- [ ] DevOps
- [ ] Others:

**Overview of changes**
* Fix room crashing when question fetching fails, fixed #100 
* Remove duplicated code in room
* Added room dialog to end session as well as client socket, resolves #101 

**How it was tested/How to test**

1. Run all services w/ root docker compose 
2. Match 2 users
3. In either user, terminate the room. It should inform both users in the room and redirect them out after 4s (edit: screenshot is slightly outdated, clicking confirm now closes the dialog as well)
![endRoom](https://user-images.githubusercontent.com/50147457/192439540-3fec5991-e362-44e2-9bdd-19eea1dc2536.gif)

Note: I am still unable to run Question Service due to the same postgresql error, so for match service I hardcoded the qn id to be 1. 
![image](https://user-images.githubusercontent.com/50147457/192440171-fe4cf62c-9965-4a74-8d17-e3243a9d755e.png)


**Service(s) Touched**

- [x] Frontend
- [ ] User Service
- [x] Matching Service
- [ ] Question Service
- [ ] Collaboration Service
