### PR TITLE
Fix test for duplicate roomId

### DIFF
--- a/history-service/test/index.test.js
+++ b/history-service/test/index.test.js
@@ -35,16 +35,25 @@ describe('POST /room (create room history)', function () {
     expect(resp.body.message).to.equal('Created room history')
   })
 
-  it('fails for duplicate roomId', function (done) {
-    request(app)
+  it('fails for duplicate roomId', async function () {
+    // Make sure there is a duplicate room
+    await request(app)
       .post(`${URI_PREFIX}/room`)
       .send({
         'roomId': 'testRoom',
         'u1': 'testUser1',
         'u2': 'testUser2',
       })
-      .expect(400)
-      .expect({ message: 'Could not create room history for roomId testRoom' }, done)
+    
+    const resp = await request(app)
+      .post(`${URI_PREFIX}/room`)
+      .send({
+        'roomId': 'testRoom',
+        'u1': 'testUser1',
+        'u2': 'testUser2',
+      })
+    expect(resp.statusCode).to.equal(400)
+    expect(resp.body.message).to.equal('Could not create room history for roomId testRoom')
   })
 
   it('fails for missing fields in request body', function (done) {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance or refactor
- [x] Test
- [ ] DevOps
- [ ] Others:

**Overview of changes**
Fixes #175
History service CI/CD was not passing consistently, once in a while the test for duplicate roomId fails. 
* Test 1 creates the roomId, and subsequently test 2 tries to recreate the same roomId.
* Sometimes, test 2 fails (expect: should not be able to recreate, got: created successfully)
 
Approach to fix:  Create the same roomId before running test 2 (i.e. do **not** rely on persistent state from test 1)

**How it was tested/How to test**

**Service(s) Touched**

- [ ] Frontend
- [ ] User Service
- [ ] Matching Service
- [ ] Question Service
- [ ] Collaboration Service
- [x] History Service
- [ ] Room Service
